### PR TITLE
Fix library auto-import structure

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,4 +4,4 @@
 (c) 2023-present NKA Development Organization
 """
 
-from . import api
+from .api import *


### PR DESCRIPTION
I finally found out why api sub-library wasn't working directly. This patch fixes this issue.